### PR TITLE
module 'jsoncpp' provides target 'jsoncpp-ext' instead of 'jsoncpp'

### DIFF
--- a/jsoncpp/CMakeLists.txt
+++ b/jsoncpp/CMakeLists.txt
@@ -4,9 +4,13 @@
 set(jsoncpp_VERSION 2.4)
 
 define_module(LIBRARY jsoncpp=${jsoncpp_VERSION}
-  DEPENDS utility>=1.41
+  DEPENDS BuildSystem>=1.15
+  utility>=1.41
   JSONCPP
-  Boost)
+  Boost
+  # NB: this module provides target with different name
+  PROVIDES jsoncpp-ext
+  )
 
 set(jsoncpp_SOURCES
   as.hpp
@@ -14,9 +18,9 @@ set(jsoncpp_SOURCES
   io.hpp io.cpp
 )
 
-add_library(jsoncpp STATIC ${jsoncpp_SOURCES})
-target_link_libraries(jsoncpp ${MODULE_LIBRARIES})
-target_compile_definitions(jsoncpp PRIVATE ${MODULE_DEFINITIONS})
+add_library(jsoncpp-ext STATIC ${jsoncpp_SOURCES})
+target_link_libraries(jsoncpp-ext ${MODULE_LIBRARIES})
+target_compile_definitions(jsoncpp-ext PRIVATE ${MODULE_DEFINITIONS})
 
-set_target_properties(jsoncpp PROPERTIES LINKER_LANGUAGE CXX)
-buildsys_library(jsoncpp)
+set_target_properties(jsoncpp-ext PROPERTIES LINKER_LANGUAGE CXX)
+buildsys_library(jsoncpp-ext)


### PR DESCRIPTION
Depends on `BuildSystem>=1.15`.
Target renamed to `jsoncpp-ext`.